### PR TITLE
Add a guard against edge case with zero span in linear guessing

### DIFF
--- a/src/FindFirstFunctions.jl
+++ b/src/FindFirstFunctions.jl
@@ -233,7 +233,9 @@ end
 function (g::Guesser)(x)
     (; v, idx_prev, linear_lookup) = g
     if linear_lookup
-        f = (x - first(v)) / (last(v) - first(v))
+        δx = x - first(v)
+        δx == 0 && return firstindex(v)
+        f = δx / (last(v) - first(v))
         if isinf(f)
             f > 0 ? lastindex(v) : firstindex(v)
         else

--- a/src/FindFirstFunctions.jl
+++ b/src/FindFirstFunctions.jl
@@ -234,7 +234,7 @@ function (g::Guesser)(x)
     (; v, idx_prev, linear_lookup) = g
     if linear_lookup
         δx = x - first(v)
-        δx == 0 && return firstindex(v)
+        iszero(δx) && return firstindex(v)
         f = δx / (last(v) - first(v))
         if isinf(f)
             f > 0 ? lastindex(v) : firstindex(v)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,5 +39,19 @@ using SafeTestsets, Test
         @test searchsortedfirstcorrelated(v, 4.0, guesser_linear) == 3
         @test searchsortedlastcorrelated(v, 4.0, guesser_prev) == 2
         @test guesser_prev.idx_prev[] == 2
+
+        # Edge case 
+        v1 = [42.0]
+        guesser = Guesser(v1)
+        @test guesser_linear.linear_lookup
+        @test guesser(100) == 1
+        @test guesser(42.0) == 1
+        @test guesser(0) == 1
+        @test searchsortedfirstcorrelated(v1, 0, guesser) == 1
+        @test searchsortedfirstcorrelated(v1, 100, guesser) == 1 + 1  # see searchsortedfirst
+        @test searchsortedfirstcorrelated(v1, 42.0, guesser) == 1
+        @test searchsortedlastcorrelated(v1, 0, guesser) == 1 - 1 # see searchsortedlast
+        @test searchsortedlastcorrelated(v1, 100, guesser) == 1
+        @test searchsortedlastcorrelated(v1, 42.0, guesser) == 1
     end
 end


### PR DESCRIPTION
If the span of the vector (`last(v) - first(v)`) is 0, the current linear guessing relies on an `isinf` guard. This fails for one value, `first(v)`, since the linear quotient 0/0 produces a NaN instead of +Inf or -Inf. This PR aims to patch that edge case.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
