### PR TITLE
Fix deprecations in Julia 1.12

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -25,6 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - "min"
           - "1"
           - "lts"
           - "pre"
@@ -36,4 +37,5 @@ jobs:
     with:
       julia-version: "${{ matrix.version }}"
       os: "${{ matrix.os }}"
+      julia-runtest-depwarn: "error"
     secrets: "inherit"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -25,7 +25,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "min"
           - "1"
           - "lts"
           - "pre"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FindFirstFunctions"
 uuid = "64ca27bc-2ba2-4a57-88aa-44e436879224"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
-version = "1.4.1"
+version = "1.4.2"
 
 [compat]
 Aqua = "0.8"

--- a/src/FindFirstFunctions.jl
+++ b/src/FindFirstFunctions.jl
@@ -1,4 +1,5 @@
 module FindFirstFunctions
+
 # https://github.com/JuliaLang/julia/pull/53687
 const USE_PTR = VERSION >= v"1.12.0-DEV.255"
 const FFE_IR = """

--- a/src/FindFirstFunctions.jl
+++ b/src/FindFirstFunctions.jl
@@ -1,130 +1,70 @@
 module FindFirstFunctions
 
+const USE_PTR = VERSION >= v"1.12.0-DEV.255"
+const FFE_IR = """
+    declare i8 @llvm.cttz.i8(i8, i1);
+    define i64 @entry(i64 %0, $(USE_PTR ? "ptr" : "i64") %1, i64 %2) #0 {
+    top:
+      $(USE_PTR ? "" : "%ivars = inttoptr i64 %1 to i64*")
+      %btmp = insertelement <8 x i64> undef, i64 %0, i64 0
+      %var = shufflevector <8 x i64> %btmp, <8 x i64> undef, <8 x i32> zeroinitializer
+      %lenm7 = add nsw i64 %2, -7
+      %dosimditer = icmp ugt i64 %2, 7
+      br i1 %dosimditer, label %L9.lr.ph, label %L32
+
+    L9.lr.ph:
+      %len8 = and i64 %2, 9223372036854775800
+      br label %L9
+
+    L9:
+      %i = phi i64 [ 0, %L9.lr.ph ], [ %vinc, %L30 ]
+      %ivarsi = getelementptr inbounds i64, $(USE_PTR ? "ptr %1" : "i64* %ivars"), i64 %i
+      $(USE_PTR ? "" : "%vpvi = bitcast i64* %ivarsi to <8 x i64>*")
+      %v = load <8 x i64>, $(USE_PTR ? "ptr %ivarsi" : "<8 x i64> * %vpvi"), align 8
+      %m = icmp eq <8 x i64> %v, %var
+      %mu = bitcast <8 x i1> %m to i8
+      %matchnotfound = icmp eq i8 %mu, 0
+      br i1 %matchnotfound, label %L30, label %L17
+
+    L17:
+      %tz8 = call i8 @llvm.cttz.i8(i8 %mu, i1 true)
+      %tz64 = zext i8 %tz8 to i64
+      %vis = add nuw i64 %i, %tz64
+      br label %common.ret
+
+    common.ret:
+      %retval = phi i64 [ %vis, %L17 ], [ -1, %L32 ], [ %si, %L51 ], [ -1, %L67 ]
+      ret i64 %retval
+
+    L30:
+      %vinc = add nuw nsw i64 %i, 8
+      %continue = icmp slt i64 %vinc, %lenm7
+      br i1 %continue, label %L9, label %L32
+
+    L32:
+      %cumi = phi i64 [ 0, %top ], [ %len8, %L30 ]
+      %done = icmp eq i64 %cumi, %2
+      br i1 %done, label %common.ret, label %L51
+
+    L51:
+      %si = phi i64 [ %inc, %L67 ], [ %cumi, %L32 ]
+      %spi = getelementptr inbounds i64, $(USE_PTR ? "ptr %1" : "i64* %ivars"), i64 %si
+      %svi = load i64, $(USE_PTR ? "ptr" : "i64*") %spi, align 8
+      %match = icmp eq i64 %svi, %0
+      br i1 %match, label %common.ret, label %L67
+
+    L67:
+      %inc = add i64 %si, 1
+      %dobreak = icmp eq i64 %inc, %2
+      br i1 %dobreak, label %common.ret, label %L51
+
+    }
+    attributes #0 = { alwaysinline }
+    """
+
 function _findfirstequal(vpivot::Int64, ptr::Ptr{Int64}, len::Int64)
-    # https://github.com/JuliaLang/julia/pull/53687
-    mod_ir = if VERSION >= v"1.12.0-DEV.225"
-        # Julia 1.12+ version with actual pointer types
-        """
-        declare i8 @llvm.cttz.i8(i8, i1);
-        define i64 @entry(i64 %0, ptr %1, i64 %2) #0 {
-        top:
-          %btmp = insertelement <8 x i64> undef, i64 %0, i64 0
-          %var = shufflevector <8 x i64> %btmp, <8 x i64> undef, <8 x i32> zeroinitializer
-          %lenm7 = add nsw i64 %2, -7
-          %dosimditer = icmp ugt i64 %2, 7
-          br i1 %dosimditer, label %L9.lr.ph, label %L32
-
-        L9.lr.ph:
-          %len8 = and i64 %2, 9223372036854775800
-          br label %L9
-
-        L9:
-          %i = phi i64 [ 0, %L9.lr.ph ], [ %vinc, %L30 ]
-          %vpvi = getelementptr inbounds i64, ptr %1, i64 %i
-          %v = load <8 x i64>, ptr %vpvi, align 8
-          %m = icmp eq <8 x i64> %v, %var
-          %mu = bitcast <8 x i1> %m to i8
-          %matchnotfound = icmp eq i8 %mu, 0
-          br i1 %matchnotfound, label %L30, label %L17
-
-        L17:
-          %tz8 = call i8 @llvm.cttz.i8(i8 %mu, i1 true)
-          %tz64 = zext i8 %tz8 to i64
-          %vis = add nuw i64 %i, %tz64
-          br label %common.ret
-
-        common.ret:
-          %retval = phi i64 [ %vis, %L17 ], [ -1, %L32 ], [ %si, %L51 ], [ -1, %L67 ]
-          ret i64 %retval
-
-        L30:
-          %vinc = add nuw nsw i64 %i, 8
-          %continue = icmp slt i64 %vinc, %lenm7
-          br i1 %continue, label %L9, label %L32
-
-        L32:
-          %cumi = phi i64 [ 0, %top ], [ %len8, %L30 ]
-          %done = icmp eq i64 %cumi, %2
-          br i1 %done, label %common.ret, label %L51
-
-        L51:
-          %si = phi i64 [ %inc, %L67 ], [ %cumi, %L32 ]
-          %spi = getelementptr inbounds i64, ptr %1, i64 %si
-          %svi = load i64, ptr %spi, align 8
-          %match = icmp eq i64 %svi, %0
-          br i1 %match, label %common.ret, label %L67
-
-        L67:
-          %inc = add i64 %si, 1
-          %dobreak = icmp eq i64 %inc, %2
-          br i1 %dobreak, label %common.ret, label %L51
-
-        }
-        attributes #0 = { alwaysinline }
-        """
-    else
-        """
-        declare i8 @llvm.cttz.i8(i8, i1);
-        define i64 @entry(i64 %0, i64 %1, i64 %2) #0 {
-        top:
-          %ivars = inttoptr i64 %1 to i64*
-          %btmp = insertelement <8 x i64> undef, i64 %0, i64 0
-          %var = shufflevector <8 x i64> %btmp, <8 x i64> undef, <8 x i32> zeroinitializer
-          %lenm7 = add nsw i64 %2, -7
-          %dosimditer = icmp ugt i64 %2, 7
-          br i1 %dosimditer, label %L9.lr.ph, label %L32
-
-        L9.lr.ph:
-          %len8 = and i64 %2, 9223372036854775800
-          br label %L9
-
-        L9:
-          %i = phi i64 [ 0, %L9.lr.ph ], [ %vinc, %L30 ]
-          %ivarsi = getelementptr inbounds i64, i64* %ivars, i64 %i
-          %vpvi = bitcast i64* %ivarsi to <8 x i64>*
-          %v = load <8 x i64>, <8 x i64>* %vpvi, align 8
-          %m = icmp eq <8 x i64> %v, %var
-          %mu = bitcast <8 x i1> %m to i8
-          %matchnotfound = icmp eq i8 %mu, 0
-          br i1 %matchnotfound, label %L30, label %L17
-
-        L17:
-          %tz8 = call i8 @llvm.cttz.i8(i8 %mu, i1 true)
-          %tz64 = zext i8 %tz8 to i64
-          %vis = add nuw i64 %i, %tz64
-          br label %common.ret
-
-        common.ret:
-          %retval = phi i64 [ %vis, %L17 ], [ -1, %L32 ], [ %si, %L51 ], [ -1, %L67 ]
-          ret i64 %retval
-
-        L30:
-          %vinc = add nuw nsw i64 %i, 8
-          %continue = icmp slt i64 %vinc, %lenm7
-          br i1 %continue, label %L9, label %L32
-
-        L32:
-          %cumi = phi i64 [ 0, %top ], [ %len8, %L30 ]
-          %done = icmp eq i64 %cumi, %2
-          br i1 %done, label %common.ret, label %L51
-
-        L51:
-          %si = phi i64 [ %inc, %L67 ], [ %cumi, %L32 ]
-          %spi = getelementptr inbounds i64, i64* %ivars, i64 %si
-          %svi = load i64, i64* %spi, align 8
-          %match = icmp eq i64 %svi, %0
-          br i1 %match, label %common.ret, label %L67
-
-        L67:
-          %inc = add i64 %si, 1
-          %dobreak = icmp eq i64 %inc, %2
-          br i1 %dobreak, label %common.ret, label %L51
-        }
-        attributes #0 = { alwaysinline }
-        """
-    end
     Base.llvmcall(
-        (mod_ir, "entry"),
+        (FFE_IR, "entry"),
         Int64,
         Tuple{Int64, Ptr{Int64}, Int64},
         vpivot,

--- a/src/FindFirstFunctions.jl
+++ b/src/FindFirstFunctions.jl
@@ -1,70 +1,130 @@
 module FindFirstFunctions
 
 function _findfirstequal(vpivot::Int64, ptr::Ptr{Int64}, len::Int64)
+    # https://github.com/JuliaLang/julia/pull/53687
+    mod_ir = if VERSION >= v"1.12.0-DEV.225"
+        # Julia 1.12+ version with actual pointer types
+        """
+        declare i8 @llvm.cttz.i8(i8, i1);
+        define i64 @entry(i64 %0, ptr %1, i64 %2) #0 {
+        top:
+          %btmp = insertelement <8 x i64> undef, i64 %0, i64 0
+          %var = shufflevector <8 x i64> %btmp, <8 x i64> undef, <8 x i32> zeroinitializer
+          %lenm7 = add nsw i64 %2, -7
+          %dosimditer = icmp ugt i64 %2, 7
+          br i1 %dosimditer, label %L9.lr.ph, label %L32
+
+        L9.lr.ph:
+          %len8 = and i64 %2, 9223372036854775800
+          br label %L9
+
+        L9:
+          %i = phi i64 [ 0, %L9.lr.ph ], [ %vinc, %L30 ]
+          %vpvi = getelementptr inbounds i64, ptr %1, i64 %i
+          %v = load <8 x i64>, ptr %vpvi, align 8
+          %m = icmp eq <8 x i64> %v, %var
+          %mu = bitcast <8 x i1> %m to i8
+          %matchnotfound = icmp eq i8 %mu, 0
+          br i1 %matchnotfound, label %L30, label %L17
+
+        L17:
+          %tz8 = call i8 @llvm.cttz.i8(i8 %mu, i1 true)
+          %tz64 = zext i8 %tz8 to i64
+          %vis = add nuw i64 %i, %tz64
+          br label %common.ret
+
+        common.ret:
+          %retval = phi i64 [ %vis, %L17 ], [ -1, %L32 ], [ %si, %L51 ], [ -1, %L67 ]
+          ret i64 %retval
+
+        L30:
+          %vinc = add nuw nsw i64 %i, 8
+          %continue = icmp slt i64 %vinc, %lenm7
+          br i1 %continue, label %L9, label %L32
+
+        L32:
+          %cumi = phi i64 [ 0, %top ], [ %len8, %L30 ]
+          %done = icmp eq i64 %cumi, %2
+          br i1 %done, label %common.ret, label %L51
+
+        L51:
+          %si = phi i64 [ %inc, %L67 ], [ %cumi, %L32 ]
+          %spi = getelementptr inbounds i64, ptr %1, i64 %si
+          %svi = load i64, ptr %spi, align 8
+          %match = icmp eq i64 %svi, %0
+          br i1 %match, label %common.ret, label %L67
+
+        L67:
+          %inc = add i64 %si, 1
+          %dobreak = icmp eq i64 %inc, %2
+          br i1 %dobreak, label %common.ret, label %L51
+
+        }
+        attributes #0 = { alwaysinline }
+        """
+    else
+        """
+        declare i8 @llvm.cttz.i8(i8, i1);
+        define i64 @entry(i64 %0, i64 %1, i64 %2) #0 {
+        top:
+          %ivars = inttoptr i64 %1 to i64*
+          %btmp = insertelement <8 x i64> undef, i64 %0, i64 0
+          %var = shufflevector <8 x i64> %btmp, <8 x i64> undef, <8 x i32> zeroinitializer
+          %lenm7 = add nsw i64 %2, -7
+          %dosimditer = icmp ugt i64 %2, 7
+          br i1 %dosimditer, label %L9.lr.ph, label %L32
+
+        L9.lr.ph:
+          %len8 = and i64 %2, 9223372036854775800
+          br label %L9
+
+        L9:
+          %i = phi i64 [ 0, %L9.lr.ph ], [ %vinc, %L30 ]
+          %ivarsi = getelementptr inbounds i64, i64* %ivars, i64 %i
+          %vpvi = bitcast i64* %ivarsi to <8 x i64>*
+          %v = load <8 x i64>, <8 x i64>* %vpvi, align 8
+          %m = icmp eq <8 x i64> %v, %var
+          %mu = bitcast <8 x i1> %m to i8
+          %matchnotfound = icmp eq i8 %mu, 0
+          br i1 %matchnotfound, label %L30, label %L17
+
+        L17:
+          %tz8 = call i8 @llvm.cttz.i8(i8 %mu, i1 true)
+          %tz64 = zext i8 %tz8 to i64
+          %vis = add nuw i64 %i, %tz64
+          br label %common.ret
+
+        common.ret:
+          %retval = phi i64 [ %vis, %L17 ], [ -1, %L32 ], [ %si, %L51 ], [ -1, %L67 ]
+          ret i64 %retval
+
+        L30:
+          %vinc = add nuw nsw i64 %i, 8
+          %continue = icmp slt i64 %vinc, %lenm7
+          br i1 %continue, label %L9, label %L32
+
+        L32:
+          %cumi = phi i64 [ 0, %top ], [ %len8, %L30 ]
+          %done = icmp eq i64 %cumi, %2
+          br i1 %done, label %common.ret, label %L51
+
+        L51:
+          %si = phi i64 [ %inc, %L67 ], [ %cumi, %L32 ]
+          %spi = getelementptr inbounds i64, i64* %ivars, i64 %si
+          %svi = load i64, i64* %spi, align 8
+          %match = icmp eq i64 %svi, %0
+          br i1 %match, label %common.ret, label %L67
+
+        L67:
+          %inc = add i64 %si, 1
+          %dobreak = icmp eq i64 %inc, %2
+          br i1 %dobreak, label %common.ret, label %L51
+        }
+        attributes #0 = { alwaysinline }
+        """
+    end
     Base.llvmcall(
-        (
-            """
-                    declare i8 @llvm.cttz.i8(i8, i1);
-                    define i64 @entry(i64 %0, i64 %1, i64 %2) #0 {
-                    top:
-                      %ivars = inttoptr i64 %1 to i64*
-                      %btmp = insertelement <8 x i64> undef, i64 %0, i64 0
-                      %var = shufflevector <8 x i64> %btmp, <8 x i64> undef, <8 x i32> zeroinitializer
-                      %lenm7 = add nsw i64 %2, -7
-                      %dosimditer = icmp ugt i64 %2, 7
-                      br i1 %dosimditer, label %L9.lr.ph, label %L32
-
-                    L9.lr.ph:
-                      %len8 = and i64 %2, 9223372036854775800
-                      br label %L9
-
-                    L9:
-                      %i = phi i64 [ 0, %L9.lr.ph ], [ %vinc, %L30 ]
-                      %ivarsi = getelementptr inbounds i64, i64* %ivars, i64 %i
-                      %vpvi = bitcast i64* %ivarsi to <8 x i64>*
-                      %v = load <8 x i64>, <8 x i64>* %vpvi, align 8
-                      %m = icmp eq <8 x i64> %v, %var
-                      %mu = bitcast <8 x i1> %m to i8
-                      %matchnotfound = icmp eq i8 %mu, 0
-                      br i1 %matchnotfound, label %L30, label %L17
-
-                    L17:
-                      %tz8 = call i8 @llvm.cttz.i8(i8 %mu, i1 true)
-                      %tz64 = zext i8 %tz8 to i64
-                      %vis = add nuw i64 %i, %tz64
-                      br label %common.ret
-
-                    common.ret:
-                      %retval = phi i64 [ %vis, %L17 ], [ -1, %L32 ], [ %si, %L51 ], [ -1, %L67 ]
-                      ret i64 %retval
-
-                    L30:
-                      %vinc = add nuw nsw i64 %i, 8
-                      %continue = icmp slt i64 %vinc, %lenm7
-                      br i1 %continue, label %L9, label %L32
-
-                    L32:
-                      %cumi = phi i64 [ 0, %top ], [ %len8, %L30 ]
-                      %done = icmp eq i64 %cumi, %2
-                      br i1 %done, label %common.ret, label %L51
-
-                    L51:
-                      %si = phi i64 [ %inc, %L67 ], [ %cumi, %L32 ]
-                      %spi = getelementptr inbounds i64, i64* %ivars, i64 %si
-                      %svi = load i64, i64* %spi, align 8
-                      %match = icmp eq i64 %svi, %0
-                      br i1 %match, label %common.ret, label %L67
-
-                    L67:
-                      %inc = add i64 %si, 1
-                      %dobreak = icmp eq i64 %inc, %2
-                      br i1 %dobreak, label %common.ret, label %L51
-
-                    }
-                    attributes #0 = { alwaysinline }
- """,
-            "entry"
-        ),
+        (mod_ir, "entry"),
         Int64,
         Tuple{Int64, Ptr{Int64}, Int64},
         vpivot,

--- a/src/FindFirstFunctions.jl
+++ b/src/FindFirstFunctions.jl
@@ -1,5 +1,5 @@
 module FindFirstFunctions
-
+# https://github.com/JuliaLang/julia/pull/53687
 const USE_PTR = VERSION >= v"1.12.0-DEV.255"
 const FFE_IR = """
     declare i8 @llvm.cttz.i8(i8, i1);


### PR DESCRIPTION
Fixes #35.

To demonstrate that the PR actually fixes the issue and to avoid regressions, I enabled `--depwarn=error` for the tests. The last CI log on master shows the deprecations (e.g. https://github.com/SciML/FindFirstFunctions.jl/actions/runs/17587897576/job/49960746174?pr=36#step:6:102) whereas tests in this PR pass and (of course) CI logs don't show any deprecation warnings.