### PR TITLE
Add PrecompileTools workload to improve TTFX

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,14 @@
 name = "FindFirstFunctions"
 uuid = "64ca27bc-2ba2-4a57-88aa-44e436879224"
-authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
 version = "1.4.2"
+authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
+
+[deps]
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [compat]
 Aqua = "0.8"
+PrecompileTools = "1"
 SafeTestsets = "0.1"
 Test = "1.10"
 julia = "1.10"

--- a/src/FindFirstFunctions.jl
+++ b/src/FindFirstFunctions.jl
@@ -298,4 +298,43 @@ function searchsortedlastcorrelated(v::T, x, guess::Guesser{T}) where {T <: Abst
     out
 end
 
+using PrecompileTools
+
+@setup_workload begin
+    # Minimal setup for precompilation workload
+    vec_int64 = Int64[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+    linear_vec = collect(1.0:0.5:10.0)
+
+    @compile_workload begin
+        # Precompile the most commonly used functions with typical types
+
+        # findfirstequal: fast SIMD-based search in Int64 vectors
+        findfirstequal(Int64(5), vec_int64)
+        findfirstequal(Int64(100), vec_int64)  # not found case
+
+        # findfirstsortedequal: binary search in sorted Int64 vectors
+        findfirstsortedequal(Int64(8), vec_int64)
+        findfirstsortedequal(Int64(100), vec_int64)  # not found case
+
+        # bracketstrictlymontonic: bracketing for sorted vectors
+        bracketstrictlymontonic(vec_int64, Int64(8), Int64(1), Base.Order.Forward)
+
+        # looks_linear: check if vector is evenly spaced
+        looks_linear(linear_vec)
+
+        # Guesser: wrapper for efficient repeated searches
+        guesser = Guesser(linear_vec)
+        guesser(5.0)
+
+        # searchsortedfirstcorrelated and searchsortedlastcorrelated
+        searchsortedfirstcorrelated(vec_int64, Int64(8), Int64(1))
+        searchsortedlastcorrelated(vec_int64, Int64(8), Int64(1))
+
+        # Also precompile with Guesser
+        guesser_int = Guesser(vec_int64)
+        searchsortedfirstcorrelated(vec_int64, Int64(8), guesser_int)
+        searchsortedlastcorrelated(vec_int64, Int64(8), guesser_int)
+    end
+end
+
 end # module FindFirstFunctions


### PR DESCRIPTION
## Summary

- Add PrecompileTools.jl as a dependency
- Add `@compile_workload` block to precompile commonly-used functions
- Dramatically reduces time-to-first-execution (TTFX) for all exported functions

## TTFX Improvements

| Function                        | Before (ms) | After (ms) | Speedup |
|--------------------------------|-------------|------------|---------|
| findfirstequal                 | 16.75       | 0.06       | ~280x   |
| findfirstsortedequal           | 23.14       | 0.06       | ~386x   |
| bracketstrictlymontonic        | 15.27       | 0.09       | ~170x   |
| looks_linear                   | 53.30       | 0.04       | ~1333x  |
| Guesser creation               | 59.16       | 0.06       | ~986x   |
| searchsortedfirstcorrelated    | 11.74       | 0.03       | ~391x   |
| searchsortedlastcorrelated     | 10.70       | 0.03       | ~357x   |

Package startup time increases from ~4ms to ~69ms, which is an acceptable tradeoff for the dramatic TTFX improvements.

## What's Precompiled

The workload precompiles the most commonly-used functions with typical types:
- `findfirstequal` with `Int64` vectors (both found and not-found cases)
- `findfirstsortedequal` with `Int64` vectors (both found and not-found cases)
- `bracketstrictlymontonic` with `Int64` vectors
- `looks_linear` with `Float64` vectors
- `Guesser` creation and usage
- `searchsortedfirstcorrelated` with both `Integer` and `Guesser` variants
- `searchsortedlastcorrelated` with both `Integer` and `Guesser` variants

## Test plan

- [x] Run `Pkg.test()` - all 25,435 tests pass
- [x] Verify TTFX improvements with fresh Julia sessions
- [x] Check for invalidations (none found)

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)