### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,3 +1,0 @@
-style = "sciml"
-format_markdown = true
-format_docstrings = true

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,0 +1,19 @@
+name: format-check
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'main'
+      - 'release-'
+    tags: '*'
+  pull_request:
+
+jobs:
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,9 +16,9 @@ using SafeTestsets, Test
             if length(x) > 0
                 @test FindFirstFunctions.findfirstequal(x[begin], @view(x[begin:end])) === 1
                 @test FindFirstFunctions.findfirstequal(x[begin], @view(x[(begin + 1):end])) ===
-                      nothing
+                    nothing
                 @test FindFirstFunctions.findfirstequal(x[end], @view(x[begin:(end - 1)])) ===
-                      nothing
+                    nothing
             end
             y = rand(Int)
             ff = findfirst(==(y), x)
@@ -30,8 +30,8 @@ using SafeTestsets, Test
 
     @safetestset "Guesser" begin
         using FindFirstFunctions:
-                                  Guesser, searchsortedfirstcorrelated,
-                                  searchsortedlastcorrelated
+            Guesser, searchsortedfirstcorrelated,
+            searchsortedlastcorrelated
         v = collect(LinRange(0, 10, 4))
         guesser_linear = Guesser(v)
         guesser_prev = Guesser(v, Ref(1), false)


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)