### PR TITLE
Centralize CI on SciML reusable workflows (@v1)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,12 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"
       - "/docs"
-      - "/test"
+      - "/bench"
+      - "/test/qa"
     schedule:
       interval: "daily"
     groups:

--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -20,50 +20,7 @@ permissions:
 
 jobs:
   benchmark:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0   # we need both PR head and base branch
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: "1.11"
-      - uses: julia-actions/cache@v3
-      - name: Install AirspeedVelocity
-        run: |
-          julia -e 'using Pkg; Pkg.add(PackageSpec(name="AirspeedVelocity", version="0.6"))'
-      # Resolve commit shas explicitly so AirspeedVelocity sees stable refs.
-      - name: Resolve refs
-        id: resolve
-        run: |
-          PR_SHA=$(git rev-parse HEAD)
-          BASE_SHA=$(git rev-parse origin/${{ github.base_ref }})
-          echo "pr_sha=$PR_SHA"  >> "$GITHUB_OUTPUT"
-          echo "base_sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
-      - name: Run benchmark comparison
-        run: |
-          export JULIA_NUM_THREADS=1
-          ~/.julia/bin/benchpkg FindFirstFunctions \
-            --rev=${{ steps.resolve.outputs.base_sha }},${{ steps.resolve.outputs.pr_sha }} \
-            --bench-on=${{ steps.resolve.outputs.pr_sha }} \
-            --output-dir=results/ \
-            --tune
-      - name: Render comparison table
-        run: |
-          ~/.julia/bin/benchpkgtable FindFirstFunctions \
-            --rev=${{ steps.resolve.outputs.base_sha }},${{ steps.resolve.outputs.pr_sha }} \
-            --input-dir=results/ \
-            > benchmark_table.md
-          cat benchmark_table.md
-      - name: Post benchmark comment
-        if: github.event_name == 'pull_request'
-        uses: peter-evans/create-or-update-comment@v5
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body-path: benchmark_table.md
-          edit-mode: replace
-      - name: Upload raw results
-        uses: actions/upload-artifact@v7
-        with:
-          name: benchmark-results
-          path: results/
+    uses: "SciML/.github/.github/workflows/benchmark.yml@v1"
+    with:
+      julia-version: "1.11"
+    secrets: "inherit"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -13,21 +13,9 @@ on:
 jobs:
   test:
     if: false  # Disabled: PrecompileTools v1.0.0 (compat lower bound) fails on Julia 1.10. See #58.
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-#        if: ${{ matrix.version == '1.6' }}
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+      allow-reresolve: false
+    secrets: "inherit"

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -17,10 +17,7 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}/${{ matrix.version }}
-    runs-on: ${{ matrix.os }}
-    env:
-      GROUP: ${{ matrix.package.group }}
+    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}/${{ matrix.version }}/${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -33,39 +30,12 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.version }}
-          arch: x64
-      - uses: julia-actions/cache@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: julia-actions/julia-buildpkg@latest
-      - name: Clone Downstream
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
-          path: downstream
-      - name: Load this and run the downstream tests
-        shell: julia --color=yes --depwarn=error --project=downstream {0}
-        run: |
-          using Pkg
-          try
-            # force it to use this PR's version of the package
-            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
-            Pkg.update()
-            Pkg.test(coverage=true)  # resolver may fail with test time deps
-          catch err
-            err isa Pkg.Resolve.ResolverError || rethrow()
-            # If we can't resolve that means this is incompatible by SemVer and this is fine
-            # It means we marked this as a breaking change, so we don't need to worry about
-            # Mistakenly introducing a breaking change, as we have intentionally made one
-            @info "Not compatible with this release. No problem." exception=err
-            exit(0)  # Exit immediately, as a success
-          end
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v6
-        with:
-          files: lcov.info
+    uses: "SciML/.github/.github/workflows/downstream.yml@v1"
+    with:
+      julia-version: ${{ matrix.version }}
+      julia-arch: x64
+      os: ${{ matrix.os }}
+      owner: ${{ matrix.package.user }}
+      repo: ${{ matrix.package.repo }}
+      group: ${{ matrix.package.group }}
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,5 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,5 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.16.23 
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -21,7 +21,6 @@ concurrency:
 jobs:
   tests:
     name: "${{ matrix.group }} - Julia ${{ matrix.version }} - ${{ matrix.os }}"
-    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -47,30 +46,10 @@ jobs:
             os: "macos-latest"
           - group: QA
             os: "windows-latest"
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.version }}
-      - uses: actions/cache@v5
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        env:
-          GROUP: ${{ matrix.group }}
-      - uses: julia-actions/julia-processcoverage@v1
-        if: matrix.group == 'Core'
-      - uses: codecov/codecov-action@v6
-        if: matrix.group == 'Core'
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: lcov.info
-          fail_ci_if_error: false
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      group: ${{ matrix.group }}
+      julia-version: ${{ matrix.version }}
+      os: ${{ matrix.os }}
+      coverage: ${{ matrix.group == 'Core' }}
+    secrets: "inherit"

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ BenchmarkTools.Trial: 10000 samples with 1 evaluation.
  Memory estimate: 0 bytes, allocs estimate: 0.
 ```
 The branches in a binary search are unpredictable, thus disabling the conversion of `cmov` into branches results in a substantial performance increase.
-Additionally, enablig `cmov` (i.e., disabling `cmov` conversion) greatly reduces the optimal base case size for `FindFirstFunctions.findfirstsortedequal`. Without `cmov`, we need a very large base case to avoid too many branches, scanning large swaths contiguously.
+Additionally, enabling `cmov` (i.e., disabling `cmov` conversion) greatly reduces the optimal base case size for `FindFirstFunctions.findfirstsortedequal`. Without `cmov`, we need a very large base case to avoid too many branches, scanning large swaths contiguously.
 With `cmov`, we can reduce the base case size to `8`, taking several additional binary search steps without incurring heavy branch prediction penalties.
 
 However, we default to a large base case size, under the assumptions users are not setting this `ENV` variable; we assume that an expert user concerned about binary search performance who sets this variable will also be able to choose their own basecase size.

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,7 @@
+# Domain-specific words that are not typos:
+# - strat/STRAT: shorthand identifier for "strategy" used throughout benchmarks/NEWS
+# - olt: LLVM IR floating-point comparison predicate ("ordered less than")
+[default.extend-words]
+strat = "strat"
+STRAT = "STRAT"
+olt = "olt"


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas**

Converts the CI to use the centralized SciML reusable workflows pinned at `@v1`, with `secrets: "inherit"` on every caller. Matrices and behavior are preserved exactly.

## Converted (inline -> central caller)
- **Tests.yml** -> `tests.yml@v1` (preserved group×version×os matrix Core/QA × 1/lts/pre × ubuntu/macos/windows with the QA excludes; coverage only on Core)
- **Downstream.yml** -> matrix of `downstream.yml@v1` callers (DataInterpolations.jl/Core, ModelingToolkit.jl/InterfaceI; version 1; os ×3)
- **Downgrade.yml** -> `downgrade.yml@v1` (kept `if: false` disable per #58; julia-version 1.10, skip `Pkg,TOML`, allow-reresolve false)
- **FormatCheck.yml** (Runic) -> `runic.yml@v1`
- **SpellCheck.yml** (crate-ci/typos) -> `spellcheck.yml@v1`
- **Benchmark.yml** (AirspeedVelocity) -> `benchmark.yml@v1` (julia 1.11; preserved on/concurrency/permissions)

## Already central (unchanged)
- **Documentation.yml** was already a `documentation.yml@v1` caller with `secrets: "inherit"`.

## Added callers
- None new — every check already existed as inline/central and was converted/kept.

## Cleanup
- **dependabot.yml**: removed the `crate-ci/typos` version ignore; `github-actions` block kept (`/`, weekly); `julia` block now lists dirs that actually have a `Project.toml` (`/`, `/docs`, `/bench`, `/test/qa`) instead of the stale `/test` (which has no manifest); daily, group `all-julia-packages: ["*"]`.
- No `CompatHelper.yml` present. **TagBot.yml** left unchanged.

## Spelling
- Typos auto-fix: 1 genuine fix (`enablig` -> `enabling` in README.md).
- Added `_typos.toml` for domain false-positives: `strat`/`STRAT` (shorthand identifier for "strategy", used in benchmarks/NEWS) and `olt` (LLVM IR floating-point compare predicate "ordered less than"). `typos .` is clean (exit 0) on crate-ci/typos 1.47.0, matching the central caller's pinned version.

## Runic
- No formatting changes applied — the repo was already Runic-clean (it previously ran Runic inline), so `Runic.main(["--inplace","."])` produced no diff.

## Heads up
- Check names change (e.g. the reusable workflows produce job names like "Tests", "Runic Format Check", "Spell Check with Typos", "Downgrade Tests", "Build and Deploy Documentation"). **Branch-protection required-status-check names will need updating** to match the new job names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)