### PR TITLE
Re-enable downgrade CI with genuine test-at-floor (allow_reresolve: false)

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,7 +12,6 @@ on:
       - 'docs/**'
 jobs:
   test:
-    if: false  # Disabled: PrecompileTools v1.0.0 (compat lower bound) fails on Julia 1.10. See #58.
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
       julia-version: "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [compat]
 Pkg = "1.10"
-PrecompileTools = "1"
+PrecompileTools = "1.0.1"
 SafeTestsets = "0.1"
 StableRNGs = "1"
 Test = "1.10"


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.** Draft.

Re-enables the Downgrade workflow with `allow_reresolve: false` (genuine test-at-floor: tests run at the minimal/downgraded versions). Raises declared-dep `[compat]` lower bounds: `PrecompileTools = "1.0.1";`PrecompileTools = "1.0.1";

Verified locally on Julia 1.10 in a clean depot + fresh registry: downgrade resolve + `Pkg.test(allow_reresolve=false)` pass at the floor with 0 re-resolve. CI is the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)