### PR TITLE
Canonical CI: grouped-tests.yml + root test/test_groups.toml

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -20,36 +20,5 @@ concurrency:
 
 jobs:
   tests:
-    name: "${{ matrix.group }} - Julia ${{ matrix.version }} - ${{ matrix.os }}"
-    strategy:
-      fail-fast: false
-      matrix:
-        group:
-          - Core
-          - QA
-        version:
-          - "1"
-          - "lts"
-          - "pre"
-        os:
-          - "ubuntu-latest"
-          - "macos-latest"
-          - "windows-latest"
-        exclude:
-          # QA tests only run on Julia 1 (latest stable) - exclude from lts and pre
-          - group: QA
-            version: "lts"
-          - group: QA
-            version: "pre"
-          # QA tests only run on ubuntu
-          - group: QA
-            os: "macos-latest"
-          - group: QA
-            os: "windows-latest"
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      group: ${{ matrix.group }}
-      julia-version: ${{ matrix.version }}
-      os: ${{ matrix.os }}
-      coverage: ${{ matrix.group == 'Core' }}
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,11 @@
+# Root test-group matrix for FindFirstFunctions.jl, consumed by the canonical
+# SciML/.github grouped-tests.yml@v1 caller (.github/workflows/Tests.yml).
+# runtests.jl reads ENV["GROUP"] and dispatches Core / QA.
+
+[Core]
+versions = ["1", "lts", "pre"]
+os = ["ubuntu-latest", "macos-latest", "windows-latest"]
+
+[QA]
+versions = ["1"]
+os = ["ubuntu-latest"]


### PR DESCRIPTION
## Summary

Converts the root test workflow `.github/workflows/Tests.yml` to the canonical SciML/.github **`grouped-tests.yml@v1`** thin caller, moving the hand-maintained group × version × os matrix into a root **`test/test_groups.toml`**.

`test/runtests.jl` already reads `ENV["GROUP"]` and dispatches `Core` / `QA`, so **no test changes** are needed (Category A).

### Workflow change

The old `Tests.yml` carried an inline `group: [Core, QA] × version: [1, lts, pre] × os: [ubuntu, macos, windows]` matrix (with QA excluded from lts/pre and macos/windows) and delegated to `tests.yml@v1`. It now becomes a thin caller:

```yaml
jobs:
  tests:
    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
    secrets: "inherit"
```

- Filename, `name: "Tests"`, the `on:` triggers (push/PR on `main` with `paths-ignore: docs/**`, plus the Friday `schedule` cron), and the `concurrency:` block are **preserved verbatim** so branch-protection status checks are unaffected.
- **No `with:` inputs needed**: `runtests.jl` reads the default `GROUP` env var; `check-bounds` (`yes`), `coverage` (`true`), and `coverage-directories` (`src,ext`) all match the canonical defaults; there are no apt packages.

### Matrix (`test/test_groups.toml`)

```toml
[Core]
versions = ["1", "lts", "pre"]
os = ["ubuntu-latest", "macos-latest", "windows-latest"]

[QA]
versions = ["1"]
os = ["ubuntu-latest"]
```

### Matrix match

Verified by running `compute_affected_sublibraries.jl <root> --root-matrix` (from SciML/.github@v1) and comparing the emitted `(group, version, runner)` set against the old workflow's expanded matrix: **10/10 exact**.

- Core × {1, lts, pre} × {ubuntu, macos, windows} = 9 cells
- QA × {1} × {ubuntu} = 1 cell

### QA

QA (Aqua/JET) group already exists and is unchanged; no local QA run performed per Category A. TOML and YAML both parse cleanly. No metadata fixes were required (`[compat] julia` is already at the `1.10` LTS floor; `[extras]`/`[targets].test` aligned).

---

Ignore until reviewed by @ChrisRackauckas.