### PR TITLE
QA: run ubuntu-only (drop os matrix from the QA group)

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -7,5 +7,4 @@ versions = ["1", "lts", "pre"]
 os = ["ubuntu-latest", "macos-latest", "windows-latest"]
 
 [QA]
-versions = ["1"]
-os = ["ubuntu-latest"]
+versions = ["lts", "1"]


### PR DESCRIPTION
Aqua/JET checks are platform-independent, so the windows-latest and macos-latest QA jobs were just wasted CI. This strips the `os` axis from the `[QA]` group in `test/test_groups.toml` so QA runs only on the default `ubuntu-latest`.

The Core (functional) group keeps its full multi-OS coverage (ubuntu/macos/windows) — only QA is narrowed.

Ignore until reviewed by @ChrisRackauckas.