### PR TITLE
Fix QA test group on main: stale v1 API references

### DIFF
--- a/test/qa/qa_tests.jl
+++ b/test/qa/qa_tests.jl
@@ -29,9 +29,9 @@ end
     rep = JET.report_call(FindFirstFunctions.findfirstsortedequal, (Int64, Vector{Int64}))
     @test length(JET.get_reports(rep)) == 0
 
-    # bracketstrictlymontonic - bracketing for sorted vectors
+    # bracketstrictlymonotonic - bracketing for sorted vectors
     rep = JET.report_call(
-        FindFirstFunctions.bracketstrictlymontonic,
+        FindFirstFunctions.bracketstrictlymonotonic,
         (Vector{Int64}, Int64, Int64, Base.Order.ForwardOrdering)
     )
     @test length(JET.get_reports(rep)) == 0
@@ -45,17 +45,17 @@ end
     rep = JET.report_call(guesser, (Float64,))
     @test length(JET.get_reports(rep)) == 0
 
-    # searchsortedfirstcorrelated with Integer guess
+    # Strategy-dispatched searchsortedfirst with Integer hint
     rep = JET.report_call(
-        FindFirstFunctions.searchsortedfirstcorrelated,
-        (Vector{Int64}, Int64, Int64)
+        Base.searchsortedfirst,
+        (FindFirstFunctions.BracketGallop, Vector{Int64}, Int64, Int64)
     )
     @test length(JET.get_reports(rep)) == 0
 
-    # searchsortedlastcorrelated with Integer guess
+    # Strategy-dispatched searchsortedlast with Integer hint
     rep = JET.report_call(
-        FindFirstFunctions.searchsortedlastcorrelated,
-        (Vector{Int64}, Int64, Int64)
+        Base.searchsortedlast,
+        (FindFirstFunctions.BracketGallop, Vector{Int64}, Int64, Int64)
     )
     @test length(JET.get_reports(rep)) == 0
 
@@ -66,17 +66,17 @@ end
     )
     @test length(JET.get_reports(rep)) == 0
 
-    # searchsortedfirstvec - vectorized search
+    # searchsortedfirst! - batched in-place search
     rep = JET.report_call(
-        FindFirstFunctions.searchsortedfirstvec,
-        (Vector{Int64}, Vector{Int64})
+        FindFirstFunctions.searchsortedfirst!,
+        (Vector{Int64}, Vector{Int64}, Vector{Int64})
     )
     @test length(JET.get_reports(rep)) == 0
 
-    # searchsortedlastvec - vectorized search
+    # searchsortedlast! - batched in-place search
     rep = JET.report_call(
-        FindFirstFunctions.searchsortedlastvec,
-        (Vector{Int64}, Vector{Int64})
+        FindFirstFunctions.searchsortedlast!,
+        (Vector{Int64}, Vector{Int64}, Vector{Int64})
     )
     @test length(JET.get_reports(rep)) == 0
 end
@@ -98,17 +98,17 @@ end
         @test isempty(allocs)
     end
 
-    @testset "bracketstrictlymontonic" begin
+    @testset "bracketstrictlymonotonic" begin
         # Int64 vector with Forward ordering
         allocs = check_allocs(
-            FindFirstFunctions.bracketstrictlymontonic,
+            FindFirstFunctions.bracketstrictlymonotonic,
             (Vector{Int64}, Int64, Int64, Base.Order.ForwardOrdering)
         )
         @test isempty(allocs)
 
         # Float64 vector with Forward ordering
         allocs = check_allocs(
-            FindFirstFunctions.bracketstrictlymontonic,
+            FindFirstFunctions.bracketstrictlymonotonic,
             (Vector{Float64}, Float64, Int64, Base.Order.ForwardOrdering)
         )
         @test isempty(allocs)
@@ -135,34 +135,34 @@ end
         @test isempty(allocs)
     end
 
-    @testset "searchsortedfirstcorrelated" begin
-        # Int64 vector with integer guess
+    @testset "searchsortedfirst with strategy + hint" begin
+        # Int64 vector with integer hint
         allocs = check_allocs(
-            FindFirstFunctions.searchsortedfirstcorrelated,
-            (Vector{Int64}, Int64, Int64)
+            Base.searchsortedfirst,
+            (FindFirstFunctions.BracketGallop, Vector{Int64}, Int64, Int64)
         )
         @test isempty(allocs)
 
-        # Float64 vector with integer guess
+        # Float64 vector with integer hint
         allocs = check_allocs(
-            FindFirstFunctions.searchsortedfirstcorrelated,
-            (Vector{Float64}, Float64, Int64)
+            Base.searchsortedfirst,
+            (FindFirstFunctions.BracketGallop, Vector{Float64}, Float64, Int64)
         )
         @test isempty(allocs)
     end
 
-    @testset "searchsortedlastcorrelated" begin
-        # Int64 vector with integer guess
+    @testset "searchsortedlast with strategy + hint" begin
+        # Int64 vector with integer hint
         allocs = check_allocs(
-            FindFirstFunctions.searchsortedlastcorrelated,
-            (Vector{Int64}, Int64, Int64)
+            Base.searchsortedlast,
+            (FindFirstFunctions.BracketGallop, Vector{Int64}, Int64, Int64)
         )
         @test isempty(allocs)
 
-        # Float64 vector with integer guess
+        # Float64 vector with integer hint
         allocs = check_allocs(
-            FindFirstFunctions.searchsortedlastcorrelated,
-            (Vector{Float64}, Float64, Int64)
+            Base.searchsortedlast,
+            (FindFirstFunctions.BracketGallop, Vector{Float64}, Float64, Int64)
         )
         @test isempty(allocs)
     end


### PR DESCRIPTION
**Status:** Draft. Please ignore until reviewed by @ChrisRackauckas.

The `tests / QA` job has been failing on `main` since the v2.0 merge (#65) — not since the CI centralization, which only carried the failure forward. Three stale references in `test/qa/qa_tests.jl`:

- `bracketstrictlymontonic` was renamed `bracketstrictlymonotonic` (typo fix in `c1c7520`) without updating the QA tests → `UndefVarError`.
- `searchsortedfirstcorrelated` / `searchsortedlastcorrelated` were removed in `cebc780`. The JET/AllocCheck entries now exercise the strategy-API equivalents `searchsortedfirst/searchsortedlast(BracketGallop(), v, x, hint)`, which carry the same hint-driven dispatch.
- `searchsortedfirstvec` / `searchsortedlastvec` were replaced by the batched in-place `searchsortedfirst!` / `searchsortedlast!`.

**Verified locally** (Julia 1.12, `GROUP=QA`): 35/35 pass (Aqua 10, ExplicitImports 2, JET 10, AllocCheck 13). On unmodified `main` the same run errors with the `UndefVarError`s. Runic clean.

Note: #73 (v3) rewrites this file wholesale; this PR is the minimal fix to make `main` green now and can merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)