### PR TITLE
Downstream CI: drop hardcoded julia-arch x64 (breaks arm64 macOS runners)

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -33,7 +33,6 @@ jobs:
     uses: "SciML/.github/.github/workflows/downstream.yml@v1"
     with:
       julia-version: ${{ matrix.version }}
-      julia-arch: x64
       os: ${{ matrix.os }}
       owner: ${{ matrix.package.user }}
       repo: ${{ matrix.package.repo }}


### PR DESCRIPTION
**Status:** Draft. Please ignore until reviewed by @ChrisRackauckas.

The `macos-latest` downstream jobs (DataInterpolations.jl/Core, ModelingToolkit.jl/InterfaceI) have failed at the **Setup Julia** step since at least March — before the CI centralization, which preserved the same input. The runner logs show:

> `[setup-julia] x64 arch has been requested on a macOS runner that has an arm64 (Apple Silicon) architecture…`

`macos-latest` is arm64 now. The reusable `SciML/.github/.github/workflows/downstream.yml@v1` declares `julia-arch` as an optional input with no default, so dropping the hardcoded `x64` lets setup-julia pick the runner-native architecture on every OS in the matrix (ubuntu/windows x64 behavior is unchanged).

Not locally verifiable (needs a macOS arm64 runner); the evidence is the setup-julia error message plus the reusable workflow's input schema. The ubuntu/windows downstream jobs for the same matrix pass, so this is the only blocker for green downstream CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)