### PR TITLE
QA: run_qa v1.6 form + ExplicitImports

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,7 +1,6 @@
 [deps]
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 FindFirstFunctions = "64ca27bc-2ba2-4a57-88aa-44e436879224"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
@@ -11,8 +10,8 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 AllocCheck = "0.1, 0.2"
 Aqua = "0.8"
-ExplicitImports = "1.14"
 FindFirstFunctions = "1, 2.1, 3"
 JET = "0.9, 0.10, 0.11"
 SafeTestsets = "0.0.1, 0.1"
-SciMLTesting = "1"
+SciMLTesting = "1.6"
+Test = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,0 +1,22 @@
+using SciMLTesting, FindFirstFunctions, JET, Test
+
+run_qa(
+    FindFirstFunctions;
+    explicit_imports = true,
+    ei_kwargs = (;
+        # All six are Base internals accessed by qualification (GC.@preserve,
+        # Base.@propagate_inbounds, Base.Order, Base.RefValue, Base.libllvm_version,
+        # Base.llvmcall). They are not public API, so ExplicitImports flags the
+        # qualified accesses; there is no public replacement.  Source pkg: Base.
+        all_qualified_accesses_are_public = (;
+            ignore = (
+                Symbol("@preserve"),
+                Symbol("@propagate_inbounds"),
+                :Order,
+                :RefValue,
+                :libllvm_version,
+                :llvmcall,
+            ),
+        ),
+    ),
+)

--- a/test/qa/static_analysis_tests.jl
+++ b/test/qa/static_analysis_tests.jl
@@ -1,23 +1,10 @@
-using FindFirstFunctions, Aqua, ExplicitImports, JET, AllocCheck, Test
+using FindFirstFunctions, JET, AllocCheck, Test
 
-@testset "Aqua" begin
-    Aqua.find_persistent_tasks_deps(FindFirstFunctions)
-    Aqua.test_ambiguities(FindFirstFunctions, recursive = false)
-    Aqua.test_deps_compat(FindFirstFunctions)
-    Aqua.test_piracies(FindFirstFunctions)
-    Aqua.test_project_extras(FindFirstFunctions)
-    Aqua.test_stale_deps(FindFirstFunctions)
-    Aqua.test_unbound_args(FindFirstFunctions)
-    Aqua.test_undefined_exports(FindFirstFunctions)
-end
+# Beyond the package-wide JET pass in run_qa (qa.jl), assert type stability on the
+# specific hot-path call signatures, and assert they allocate nothing — guarantees
+# `JET.test_package` / `Aqua` do not make on their own.
 
-@testset "ExplicitImports" begin
-    @test check_no_implicit_imports(FindFirstFunctions) === nothing
-    @test check_no_stale_explicit_imports(FindFirstFunctions) === nothing
-end
-
-@testset "JET static analysis" begin
-    vec_int64 = Int64[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+@testset "JET static analysis (hot-path signatures)" begin
     vec_float64 = Float64[1.0, 2.0, 3.0, 4.0, 5.0]
 
     # findfirstequal - fast SIMD-based search
@@ -126,7 +113,7 @@ end
     end
 
     @testset "searchsorted_last via enum tag" begin
-        # Each kind on Int64 / Float64 dense vectors: no allocations.
+        # Each kind on Int64 dense vectors: no allocations.
         for kind in (
                 KIND_BINARY_BRACKET, KIND_LINEAR_SCAN,
                 KIND_BRACKET_GALLOP, KIND_EXP_FROM_LEFT,


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Brings `test/qa` onto the SciMLTesting 1.6 `run_qa` form with ExplicitImports enabled.

## What changed
- **`test/qa/qa.jl`** (new): `run_qa(FindFirstFunctions; explicit_imports = true, ei_kwargs = ...)`. One call now runs:
  - `Aqua.test_all` (defaults; 11 checks, including ambiguities — the old block ran `recursive = false`, but the default recursion also passes clean),
  - the package-wide JET pass (`JET.test_package`, enabled by `using JET`; `JET.report_package` returns 0 reports so `mode = :typo` is clean),
  - all six ExplicitImports checks.
- **`test/qa/static_analysis_tests.jl`** (renamed from `qa_tests.jl`): keeps the granular JET `report_call` hot-path type-stability checks and the AllocCheck zero-allocation assertions. `run_qa`'s package-wide JET pass does not cover specific call signatures or allocations, so these stay as genuine extra coverage. Still in the QA folder, so `run_tests()` runs them.
- **`test/qa/Project.toml`**: drop `ExplicitImports` (transitive via SciMLTesting); keep `Aqua` (the ambiguities sub-check's child process needs Aqua as a direct dep), `JET`, `AllocCheck`; bump `SciMLTesting` compat to `1.6`; add `Test` compat.

## ExplicitImports findings
| Check | Result |
|---|---|
| `no_implicit_imports` | pass |
| `no_stale_explicit_imports` | pass |
| `all_explicit_imports_via_owners` | pass |
| `all_qualified_accesses_via_owners` | pass |
| `all_explicit_imports_are_public` | pass |
| `all_qualified_accesses_are_public` | **ignore (6 Base internals)** |

The only finding is `all_qualified_accesses_are_public`: six Base internals accessed by qualification — `GC.@preserve`, `Base.@propagate_inbounds`, `Base.Order`, `Base.RefValue`, `Base.libllvm_version`, `Base.llvmcall`. None are public API and none have a public replacement, so they are ignored via `ei_kwargs` (source pkg: Base). No `aqua_broken` / `jet_broken` / `ei_broken` needed — nothing is known-broken.

## Verification
Run locally against released SciMLTesting 1.6.0 on Julia 1.10 (lts), 1.11, and 1.12, via the `run_tests()` folder model with `GROUP=QA`:
- `QA/qa.jl` — 18/18 Pass
- `QA/static_analysis_tests.jl` — 34/34 Pass
- 0 Fail / 0 Error / 0 Broken on every version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)