### PR TITLE
Bump version to 3.0.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FindFirstFunctions"
 uuid = "64ca27bc-2ba2-4a57-88aa-44e436879224"
-version = "3.0.1"
+version = "3.0.2"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
Automated patch version bump (3.0.1 -> 3.0.2) to release unreleased commits on `main` via JuliaRegistrator.