### PR TITLE
Release prep: bump FindFirstFunctions to 3.0.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FindFirstFunctions"
 uuid = "64ca27bc-2ba2-4a57-88aa-44e436879224"
-version = "3.0.2"
+version = "3.0.3"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
Patch release for the accumulated docstring/QA-test-scaffolding changes since 3.0.2 (enum-constant docstrings and a public-API doc-coverage test); no functional changes.