### PR TITLE
Support 32-bit platforms and add a 32-bit CI lane via test_groups.toml

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -22,12 +22,3 @@ jobs:
   tests:
     uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"
-  tests-32bit:
-    name: "Core (julia 1, ubuntu-latest, x86)"
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      julia-version: "1"
-      julia-arch: "x86"
-      group: "Core"
-      coverage: false
-    secrets: "inherit"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FindFirstFunctions"
 uuid = "64ca27bc-2ba2-4a57-88aa-44e436879224"
-version = "3.0.3"
+version = "3.1.0"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
 
 [deps]

--- a/src/equality.jl
+++ b/src/equality.jl
@@ -36,7 +36,10 @@ Find the index of the first occurrence of `var` in the sorted vector
 `DenseVector{Int64}` via a branchless binary bisection down to a small
 basecase, followed by the same SIMD equality scan that backs
 [`findfirstequal`](@ref) — faster than plain `findfirst(==(var), vars)`
-or `searchsortedfirst` + post-check for typical Int64 vectors.
+or `searchsortedfirst` + post-check for typical Int64 vectors. Every
+other element-type and array-storage combination (including native `Int`
+on 32-bit platforms, where `Int` is not `Int64`) falls back to a generic
+`searchsortedfirst` + equality post-check.
 
 The strategy-framework equivalent is
 [`findequal(BisectThenSIMD(), vars, var)`](@ref findequal); that wrapper
@@ -45,6 +48,10 @@ which is type-stable and composes with the rest of the strategy
 dispatch. Prefer `findequal` for new code; `findfirstsortedequal` remains
 as the dedicated `Union{Int64, Nothing}`-returning name.
 """
+function findfirstsortedequal(var, vars)
+    i = searchsortedfirst(vars, var)
+    return (i <= lastindex(vars) && isequal(@inbounds(vars[i]), var)) ? i : nothing
+end
 function findfirstsortedequal(
         var::Int64,
         vars::DenseVector{Int64},

--- a/test/core_tests.jl
+++ b/test/core_tests.jl
@@ -1377,3 +1377,24 @@ end
         end
     end
 end
+
+@safetestset "findfirstsortedequal generic fallback" begin
+    using FindFirstFunctions, StableRNGs
+    F = FindFirstFunctions
+
+    # The `(Int64, DenseVector{Int64})` method is the SIMD fast path; every
+    # other type (e.g. `Int32`, which is the native `Int` on 32-bit platforms)
+    # takes the generic searchsortedfirst fallback. Exercise it explicitly here
+    # so both paths are covered regardless of the host word size.
+    rng = StableRNG(2029)
+    for T in (Int32, Int16, Float32), _ in 1:500
+        n = rand(rng, 0:64)
+        v = sort!(rand(rng, T(-40):T(40), n))
+        for i in eachindex(v)
+            @test F.findfirstsortedequal(v[i], v) == searchsortedfirst(v, v[i])
+        end
+        x = rand(rng, T(-50):T(50))
+        ref = insorted(x, v) ? searchsortedfirst(v, x) : nothing
+        @test F.findfirstsortedequal(x, v) == ref
+    end
+end


### PR DESCRIPTION
Supersedes #95. Same 32-bit source support, but the CI lane is declared **through the matrix** (`test/test_groups.toml`) instead of a hand-added `tests.yml` job — and it fixes a real gap that made #95's own suite error on 32-bit.

## What changed

### Source
- **`src/simd_ir.jl`** — the LLVM-IR SIMD kernels are typed for 64-bit lengths/pointers, so guard them behind `@static if Sys.WORD_SIZE == 64` and add a portable scalar fallback `_scalar_first` backing every primitive on 32-bit. (From #95.)
- **`src/equality.jl`** — pass lengths as `Int64` explicitly (from #95), **and add a generic `findfirstsortedequal` fallback**. Unlike `findfirstequal`, `findfirstsortedequal` had *only* the `(Int64, DenseVector{Int64})` method. On 32-bit, native `Int` is `Int32`, so `findfirstsortedequal(::Int32, ::Vector{Int32})` threw `MethodError` — **8385 such errors** in the suite (this is why #95 as-is does not actually pass on 32-bit). The new method is a generic `searchsortedfirst` + equality post-check, mirroring `findfirstequal`'s fallback, so it works for any sorted vector on any platform.

### CI (the point of this PR)
Instead of #95's hand-added `tests-32bit` job in `Tests.yml`, add a `"Core 32-bit"` section to `test/test_groups.toml`:

```toml
["Core 32-bit"]
group = "Core"        # dispatch the Core body (folder resolves) on GROUP=Core
versions = ["1"]
os = ["ubuntu-latest"]
arch = "x86"
```

`Tests.yml` stays a thin caller of `grouped-tests.yml@v1`. This relies on the new **`arch` axis** and **`group` alias** added to the SciML/.github matrix generator in **SciML/.github#113** — that PR must merge and `v1` be retagged before the lane activates in CI.

### Tests & version
- Added an explicit `_scalar_first`-vs-`findfirst` parity test (from #95) and a new generic-`findfirstsortedequal` fallback test (`Int32`/`Int16`/`Float32`), so both paths are exercised on 64-bit CI too.
- Minor version bump `3.0.3 → 3.1.0` (new public behavior: `findfirstsortedequal` now accepts any sorted vector).

## Local verification (actually run, not inferred)
- **32-bit i686 Julia 1.11.9** (`juliaup add 1.11~x86`), `GROUP=Core Pkg.test()`: **passes, 0 errors** with the fix. Without the generic fallback it errored 8385 times — confirmed and root-caused.
- **x64**, final state incl. new testset: **passes, 171915 tests**.
- Both changed `.jl` files are Runic-clean.

## Dependency

Blocked on **SciML/.github#113** (arch axis + group alias). Until `v1` includes it, the `arch`/`group` keys are inert and the existing 64-bit matrix is unchanged (verified: no-arch `test_groups.toml` output is byte-identical to before).

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)