### PR TITLE
Fall back from unsafe_trunc in UniformStep kernel for non-float ratio types

### DIFF
--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -585,10 +585,12 @@ end
 # Other ordered-`Real` ratio types — `Rational`, AD `Dual`, `BigFloat`, … —
 # do not all define `unsafe_trunc`, so fall back to the checked
 # `floor(Int, ·)` / `ceil(Int, ·)`, which every such type supports and which
-# is exact for the in-range `f`.
-@inline _uniform_floor_index(f::Base.IEEEFloat) = unsafe_trunc(Int, floor(f))
+# is exact for the in-range `f`. The hardware-float union is spelled out
+# rather than via the non-public `Base.IEEEFloat` alias.
+const _HardwareFloat = Union{Float16, Float32, Float64}
+@inline _uniform_floor_index(f::_HardwareFloat) = unsafe_trunc(Int, floor(f))
 @inline _uniform_floor_index(f) = floor(Int, f)
-@inline _uniform_ceil_index(f::Base.IEEEFloat) = unsafe_trunc(Int, ceil(f))
+@inline _uniform_ceil_index(f::_HardwareFloat) = unsafe_trunc(Int, ceil(f))
 @inline _uniform_ceil_index(f) = ceil(Int, f)
 
 @inline function _kernel_last_uniform_step_props(

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -579,6 +579,18 @@ end
 # BinaryBracket.
 # ===========================================================================
 
+# Truncate a guess coordinate `f` to an `Int` offset. The caller has already
+# clamped `f` to `[0, nm1)` (last) / `(0, nm1]` (first), so on the hardware
+# floats the fast `unsafe_trunc` is in-range and skips a redundant check.
+# Other ordered-`Real` ratio types — `Rational`, AD `Dual`, `BigFloat`, … —
+# do not all define `unsafe_trunc`, so fall back to the checked
+# `floor(Int, ·)` / `ceil(Int, ·)`, which every such type supports and which
+# is exact for the in-range `f`.
+@inline _uniform_floor_index(f::Base.IEEEFloat) = unsafe_trunc(Int, floor(f))
+@inline _uniform_floor_index(f) = floor(Int, f)
+@inline _uniform_ceil_index(f::Base.IEEEFloat) = unsafe_trunc(Int, ceil(f))
+@inline _uniform_ceil_index(f) = ceil(Int, f)
+
 @inline function _kernel_last_uniform_step_props(
         props::SearchProperties, v::AbstractVector, x, order::Base.Order.Ordering,
     )
@@ -605,7 +617,7 @@ end
     elseif f >= nm1
         lastindex(v)
     else
-        firstindex(v) + unsafe_trunc(Int, floor(f))
+        firstindex(v) + _uniform_floor_index(f)
     end
     # Walk to the true cell. For exactly-uniform data this takes at most
     # one step (float roundoff); it also keeps the result correct when
@@ -640,7 +652,7 @@ end
     elseif f > nm1
         lastindex(v) + 1
     else
-        firstindex(v) + unsafe_trunc(Int, ceil(f))
+        firstindex(v) + _uniform_ceil_index(f)
     end
     @inbounds while i > firstindex(v) && !Base.Order.lt(order, v[i - 1], x)
         i -= 1

--- a/test/core_tests.jl
+++ b/test/core_tests.jl
@@ -1398,3 +1398,33 @@ end
         @test F.findfirstsortedequal(x, v) == ref
     end
 end
+
+@safetestset "UniformStep kernel across non-primitive Real eltypes" begin
+    using FindFirstFunctions
+    using FindFirstFunctions: SearchProperties, Auto, searchsorted_last, searchsorted_first
+
+    # `Rational` ratio types don't define `unsafe_trunc(Int, ·)`, so a uniform
+    # `Rational` vector — which `Auto` resolves to the closed-form
+    # `KIND_UNIFORM_STEP` path — must fall back to `floor/ceil(Int, ·)` rather
+    # than erroring. `BigFloat` exercises the non-`IEEEFloat` AbstractFloat
+    # branch of the same helper.
+    uniform_vectors = (
+        Rational{Int}[i // 4 for i in 0:4:160],
+        Rational{BigInt}[big(i) // 4 for i in 0:4:160],
+        BigFloat[BigFloat(i) for i in range(0.0, 10.0; length = 40)],
+    )
+    for v in uniform_vectors
+        @test SearchProperties(v).is_uniform
+        auto = Auto(v)
+        @test auto isa Auto
+        for i in eachindex(v)
+            @test searchsorted_last(auto, v, v[i]) == searchsortedlast(v, v[i])
+            @test searchsorted_first(auto, v, v[i]) == searchsortedfirst(v, v[i])
+        end
+        # Between-knot and out-of-range queries.
+        for q in (v[1] - one(eltype(v)), (v[3] + v[4]) / 2, v[end] + one(eltype(v)))
+            @test searchsorted_last(auto, v, q) == searchsortedlast(v, q)
+            @test searchsorted_first(auto, v, q) == searchsortedfirst(v, q)
+        end
+    end
+end


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Draft — opened by an agent.

## Problem

A uniform `Rational` vector crashes on every search:

```julia
v = Rational{Int}[i//4 for i in 0:4:160]
searchsorted_last(Auto(v), v, 5//1)
# ERROR: MethodError: no method matching unsafe_trunc(::Type{Int64}, ::Rational{Int64})
```

`Auto` resolves a uniform vector to `KIND_UNIFORM_STEP`, and the closed-form kernels compute the index offset with `unsafe_trunc(Int, floor(f))` / `unsafe_trunc(Int, ceil(f))`. `unsafe_trunc` is only defined for hardware floats and `BigFloat`; for a `Rational` ratio type it has no method. This is a pre-existing bug on `main`, independent of AD — found while testing `SearchProperties`/search robustness across element types (Float16/32/64, BigFloat, Rational, BigInt, Dual).

## Fix

`f` is already clamped to the in-range interval before truncation, so the raw `unsafe_trunc` is replaced by a small dispatch helper:

```julia
@inline _uniform_floor_index(f::Base.IEEEFloat) = unsafe_trunc(Int, floor(f))
@inline _uniform_floor_index(f) = floor(Int, f)
@inline _uniform_ceil_index(f::Base.IEEEFloat) = unsafe_trunc(Int, ceil(f))
@inline _uniform_ceil_index(f) = ceil(Int, f)
```

- `Base.IEEEFloat` hot path keeps `unsafe_trunc` (in-range, so its range check is redundant) — **unchanged**.
- Every other ordered `Real` (`Rational`, `BigFloat`, AD `Dual`, …) falls back to the checked `floor(Int, ·)`/`ceil(Int, ·)`, which those types support and which is exact for the clamped `f`.

## Tests

Adds a UniformStep regression testset over uniform `Rational{Int}`, `Rational{BigInt}`, and `BigFloat` vectors, checking search results (exact-knot, between-knot, out-of-range) against `Base`.

- Full `GROUP=Core` suite: **172,183 pass** locally.
- Runic clean.

## Independence

Independent of the AD probe PR (#100) — touches `src/kernels.jl` and a disjoint region of the test file, no shared hunks, no `ForwardDiff` dependency. Either can merge first.