### PR TITLE
Add benchmark/Project.toml so the benchmark suite resolves StableRNGs

### DIFF
--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
+
+[compat]
+StableRNGs = "1"


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Draft — opened by an agent.

## Problem

The `Benchmarks` CI job fails on every PR that touches `src/**` (seen on #100, #101):

```
ERROR: LoadError: ArgumentError: Package StableRNGs not found in current path.
```

`benchmark/benchmarks.jl` does `using StableRNGs`, but there was no `benchmark/Project.toml`. AirspeedVelocity builds a temp environment for each benchmarked revision and, when that revision's checkout contains `benchmark/Project.toml`, copies it in as the environment (it auto-adds `BenchmarkTools`/`JSON3` and the package under test, but nothing else). With no such file, `StableRNGs` never resolves.

## Fix

Add `benchmark/Project.toml` declaring `StableRNGs`. That's all AirspeedVelocity needs (it supplies `BenchmarkTools`/`JSON3` and the package itself).

## Verification

Replicated AirspeedVelocity's env construction locally — copy `benchmark/Project.toml` into a fresh env, `Pkg.develop` the package, `Pkg.add(["BenchmarkTools","JSON3"])` — then ran the unmodified `benchmark/benchmarks.jl`: `StableRNGs` resolves, the suite builds all groups (`equality` / `per_query` / `batched` / `props_construct`), and a benchmarkable runs.

## Note on CI

This PR's own `Benchmarks` check can't go green (and won't trigger): the workflow runs `benchpkg --rev=main,<PR> --bench-on=main`, so it benchmarks using **main's** checkout, which won't have `benchmark/Project.toml` until this merges. The fix takes effect on the base branch — subsequent PRs' benchmark runs then resolve cleanly.

_(Separately: the `Benchmark.yml` path filter watches `bench/**`, but the suite lives in `benchmark/**`; a one-line fix, left out here to keep this PR to just the Project.toml.)_