### PR TITLE
Use rendered docs QA in FindFirstFunctions

### DIFF
--- a/docs/src/auto.md
+++ b/docs/src/auto.md
@@ -128,12 +128,12 @@ current answer than the linear-extrapolation guess from the endpoints.
 
 ## Reproducing the benchmarks
 
-The full sweep lives at [`bench/auto_sweep.jl`](https://github.com/SciML/FindFirstFunctions.jl/blob/main/bench/auto_sweep.jl)
+The full sweep lives at [`bench/auto_sweep.jl`](https://raw.githubusercontent.com/SciML/FindFirstFunctions.jl/main/bench/auto_sweep.jl)
 with the regime grid pre-configured. Run with
 `julia --project=bench bench/auto_sweep.jl`. It evaluates every shipped
 strategy against every regime cell, computes the per-cell winner, and
 reports `Auto`'s slack distribution against that optimum. An analysis
-helper at [`bench/analyze.jl`](https://github.com/SciML/FindFirstFunctions.jl/blob/main/bench/analyze.jl)
+helper at [`bench/analyze.jl`](https://raw.githubusercontent.com/SciML/FindFirstFunctions.jl/main/bench/analyze.jl)
 reads the resulting `bench/results.csv` and prints per-strategy
 win-by-regime tables.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -61,7 +61,7 @@ searchsortedlast!(idx, v, queries)
 ## Contributing
 
   - Please refer to the
-    [SciML ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://github.com/SciML/ColPrac/blob/master/README.md)
+    [SciML ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://sciml.github.io/ColPrac/stable/)
     for guidance on PRs, issues, and other matters relating to contributing to SciML.
 
   - See the [SciML Style Guide](https://github.com/SciML/SciMLStyle) for common coding practices and other style decisions.

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -2,6 +2,7 @@ using SciMLTesting, FindFirstFunctions, JET, Test
 
 run_qa(
     FindFirstFunctions;
+    api_docs_kwargs = (; rendered = true),
     explicit_imports = true,
     ei_kwargs = (;
         # All six are Base internals accessed by qualification (GC.@preserve,
@@ -20,36 +21,3 @@ run_qa(
         ),
     ),
 )
-
-@testset "Public API documentation coverage" begin
-    public_names = setdiff(
-        Set(names(FindFirstFunctions; all = false, imported = false)),
-        Set((nameof(FindFirstFunctions),)),
-    )
-
-    documented_names = Set{Symbol}()
-    for binding in keys(Base.Docs.meta(FindFirstFunctions))
-        binding.mod === FindFirstFunctions && push!(documented_names, binding.var)
-    end
-
-    docs_names = Set{Symbol}()
-    docs_dir = joinpath(pkgdir(FindFirstFunctions), "docs", "src")
-    for file in readdir(docs_dir; join = true)
-        endswith(file, ".md") || continue
-        in_docs_block = false
-        for line in eachline(file)
-            stripped = strip(line)
-            if startswith(stripped, "```@docs")
-                in_docs_block = true
-            elseif in_docs_block && startswith(stripped, "```")
-                in_docs_block = false
-            elseif in_docs_block
-                m = match(r"^FindFirstFunctions\.([A-Za-z_][A-Za-z_0-9!]*$)", stripped)
-                m === nothing || push!(docs_names, Symbol(m.captures[1]))
-            end
-        end
-    end
-
-    @test isempty(setdiff(public_names, documented_names))
-    @test isempty(setdiff(public_names, docs_names))
-end


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary
- Replace the hand-rolled public API documentation coverage test with SciMLTesting's rendered public API docs check.
- Keep strict docs linkcheck working by replacing GitHub HTML links that returned 429 locally with stable raw/hosted URLs.

## Validation
- `git diff --check` passed.
- QA passed with `api_docs_kwargs = (; rendered = true)`: Quality Assurance 18/18.
- `Pkg.test()` passed: `Core/core_tests.jl` ran 172201 assertions.
- `include("docs/make.jl")` passed after the link updates; Documenter only emitted the expected local deployment skip warning.
- Runic v1.7.0 passed over `src`, `test`, and `docs`.
- Checked replacement URLs locally with `curl -I -L`: raw `bench/auto_sweep.jl`, raw `bench/analyze.jl`, and hosted ColPrac docs all returned HTTP 200.
