### PR TITLE
Use default public API docs QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, FindFirstFunctions, JET, Test
 
 run_qa(
     FindFirstFunctions;
-    api_docs_kwargs = (; rendered = true),
     explicit_imports = true,
     ei_kwargs = (;
         # All six are Base internals accessed by qualification (GC.@preserve,


### PR DESCRIPTION
Remove the repository-specific rendered API-docs option and use the standard SciMLTesting public API documentation check.

Validation:
- Runic 1.7 with docstrings
- `GROUP=QA Pkg.test()`
- `Pkg.test()`

Ignore until reviewed by @ChrisRackauckas.