### PR TITLE
Bump FindFirstFunctions to v3.2.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FindFirstFunctions"
 uuid = "64ca27bc-2ba2-4a57-88aa-44e436879224"
-version = "3.2.0"
+version = "3.2.1"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
Bumps `FindFirstFunctions` **v3.2.0 → v3.2.1** (patch) so the accumulated unreleased `src/` changes on `main` can be registered.

**Rationale:** Migrate FindFirstFunctions QA to SciMLTesting 2.4 (#107) (docs/QA/compat/internal; no public API or behavior break)

Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)