### PR TITLE
docs: enable Documenter doctests

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,7 +9,6 @@ makedocs(
     modules = [FindFirstFunctions],
     sitename = "FindFirstFunctions.jl",
     clean = true,
-    doctest = false,
     linkcheck = true,
     format = Documenter.HTML(
         assets = ["assets/favicon.ico"],


### PR DESCRIPTION
Remove the repository-level `doctest = false` override so standard Documenter behavior executes the package's documented examples.

Verification:
- `julia --startup-file=no --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'`
- `julia --startup-file=no --project=docs docs/make.jl` (passed with doctests enabled)
- `GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` (21/21 QA and 34/34 static checks)
- `julia --startup-file=no -m Runic --check docs/make.jl`
- `typos docs/make.jl`
- `git diff --check`

This is a docs-only configuration change. Please ignore this draft until reviewed by @ChrisRackauckas.