### PR TITLE
Drop stale [compat] majors older than one year

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [compat]
-ForwardDiff = "0.10, 1"
+ForwardDiff = "1"
 PrecompileTools = "1.0.1"
 SafeTestsets = "0.1"
 SciMLTesting = "2.4"


### PR DESCRIPTION
Drop `[compat]` majors whose first General-registry release is older than one year, and keep remaining floors on the latest major.

Policy: SciML minima sit on the latest majors. Extra majors first registered before 2025-08-26 are dropped. Majors first registered after that cutoff are kept (currently: OrdinaryDiffEqCore 4, LinearSolve 4, DiffEqDevTools 3). `julia` and stdlib entries are untouched.

| file | dep | before | after |
|---|---|---|---|
| `Project.toml` | `ForwardDiff` | `0.10, 1` | `1` |

OrdinaryDiffEqCore 4 / LinearSolve 4 / DiffEqDevTools 3 are kept where present because they were not in General a year ago.



This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
